### PR TITLE
Обновлены тире в названиях иконок для версии раскладки 3.9

### DIFF
--- a/change.sh
+++ b/change.sh
@@ -2,16 +2,17 @@
 if [[ "$OSTYPE" == "darwin"* ]]; then
   directory="$HOME/Library/Keyboard Layouts/Ilya Birman Typography Layout.bundle/Contents/Resources"
   if [ -d "$directory" ]; then
-		us="$directory/English - Ilya Birman Typography.icns"
-		ru="$directory/Russian - Ilya Birman Typography.icns"
+		us="$directory/English – Ilya Birman Typography.icns"
+		ru="$directory/Russian – Ilya Birman Typography.icns"
+		
 		mv "$us"{,.bak}
 		mv "$ru"{,.bak}
 		curl -sSL https://github.com/stamm/birman_layout_normal_icons/raw/master/flag-ru.icns > "$ru"
 		curl -sSL https://github.com/stamm/birman_layout_normal_icons/raw/master/flag-us.icns > "$us"
 		echo 'You need to restart Mac to apply icons'
 	else
-		echo 'You not install Birman Typography layout'
+		echo 'You don\'t have Birman Typography layout installed'
 	fi
 else
-  echo 'You use not mac'
+  echo 'You are not using a Mac'
 fi


### PR DESCRIPTION
> В версии 3.9 иконки русского и английского языка стали разными в новых «яйцах», которые зачем-то свисают под курсором в Сономе, а ещё тире в названиях стали той же длины, что у системных раскладок → [Сайт раскладки](https://ilyabirman.ru/typography-layout/)


Посему обновлены дефисы - на – тире в названиях иконок, иначе скрипт не срабатывает. Заодно немножко исправлены консоль-логи.